### PR TITLE
Fix output_type in config

### DIFF
--- a/fireeyeminer/node.py
+++ b/fireeyeminer/node.py
@@ -15,7 +15,7 @@ class urllistMiner(BasePollerFT):
         self.verify_cert = self.config.get('verify_cert', True)
 
         # Read the output_type from the prototype
-        self.output_type = self.config.get('output_type', 2)
+        self.output_type = self.config.get('output_type', '2')
 
         # Check if the fqdn is defined
         self.fireeye_fqdn = self.config.get('fireeye_fqdn', None)

--- a/fireeyeminer/prototypes/fireeyeminer.yml
+++ b/fireeyeminer/prototypes/fireeyeminer.yml
@@ -28,7 +28,7 @@ prototypes:
       # flag indicators with share level green
       attributes:
         share_level: green
-        output_type: 2
-        # 0 = malicious URLs only
-        # 1 = callback URLs only
-        # 2 = both
+      output_type: "2"
+      # 0 = malicious URLs only
+      # 1 = callback URLs only
+      # 2 = both


### PR DESCRIPTION
I did some tests and I think there are a couple of issues with the prototype. This PR is for fixing these issues:
- ```output_type``` is expected to be at the first level of the config, instead in the prototype is under ```attributes```. The PR moves the attribute to the first level
- ```output_type``` should be a string, while in the prototype it's a number. The PR changes the type of output_type default value to a string. Another way of fixing this would be using integer in the comparisons inside the node code.
- ```output_type``` default value in the ```configure``` method in the node is a number, while it should be a string. PR fixes this.